### PR TITLE
Correct file path for Jellyfish and modifiedJellyfish

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ cd RUFUS
 
 **2) Build**
 ```
+mkdir bin
 cd bin
 cmake ../ -DCMAKE_C_COMPILER=/path/to/gcc-4.9.2 -DCMAKE_CXX_COMPILER=/path/to/g++-4.9.2
 make
@@ -39,6 +40,7 @@ make
 If you have gcc-4.9.2 as your default compiler, you may instead use
 
 ```
+mkdir bin
 cd bin
 cmake ../ -DCMAKE_C_COMPILER=$(which gcc) -DCMAKE_CXX_COMPILER=$(which g++)
 make

--- a/externals/jellyfish.cmake
+++ b/externals/jellyfish.cmake
@@ -9,7 +9,7 @@ SET(JELLYFISH_LIB)
 ExternalProject_Add(${JELLYFISH_PROJECT}
         URL  https://github.com/gmarcais/Jellyfish/releases/download/v2.2.5/jellyfish-2.2.5.tar.gz
 
-        CONFIGURE_COMMAND ${PROJECT_SOURCE_DIR}/bin/externals/jellyfish/src/jellyfish_project/configure --prefix=${PROJECT_SOURCE_DIR}/bin/externals/jellyfish/src/jellyfish_project/
+        CONFIGURE_COMMAND ${PROJECT_BINARY_DIR}/externals/jellyfish/src/jellyfish_project/configure --prefix=${PROJECT_BINARY_DIR}/externals/jellyfish/src/jellyfish_project/
         BUILD_IN_SOURCE 1
         BUILD_COMMAND make
         INSTALL_COMMAND make install

--- a/externals/modifiedJellyfish.cmake
+++ b/externals/modifiedJellyfish.cmake
@@ -9,7 +9,7 @@ SET(MODIFIED_JELLYFISH_LIB)
 ExternalProject_Add(${MODIFIED_JELLYFISH_PROJECT}
 	URL ${PROJECT_SOURCE_DIR}/src/modifiedJellyfish.tar.gz
 
-        CONFIGURE_COMMAND ${PROJECT_SOURCE_DIR}/bin/externals/modified_jellyfish/src/modified_jellyfish_project/configure --prefix=${PROJECT_SOURCE_DIR}/bin/externals/modified_jellyfish/src/modified_jellyfish_project/
+        CONFIGURE_COMMAND ${PROJECT_BINARY_DIR}/externals/modified_jellyfish/src/modified_jellyfish_project/configure --prefix=${PROJECT_BINARY_DIR}/externals/modified_jellyfish/src/modified_jellyfish_project/
         BUILD_IN_SOURCE 1
         BUILD_COMMAND make
         INSTALL_COMMAND make install


### PR DESCRIPTION
The extracted files are actually in ${PROJECT_BINARY_DIR}.
This fixes "No such file or directory" errors during the make process.

I'm not quite sure whether --prefix should be ${PROJECT_BINARY_DIR} or ${PROJECT_SOURCE_DIR}.
Please check!